### PR TITLE
MAKE-964: remove macos-1014-i7 distro

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -274,7 +274,6 @@ buildvariants:
       goos: darwin
     run_on:
       - macos-1014
-      - macos-1014-i7
     tasks:
       - ".dist"
       - ".test"


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/MAKE-964