### PR TITLE
EVG-12672: Ensure releases and release candidates go to correct repositories

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -33,7 +33,7 @@ imports:
 - name: github.com/evergreen-ci/gimlet
   version: 7ad1845db582cfcaa26503d841f77a6277b2a258
 - name: github.com/evergreen-ci/bond
-  version: e4a29fb10c31b3651cb623b73655bc66035f83e7
+  version: 7a7b59fd9990da6e7f589cdfeb483afe6f4003f4
 - name: github.com/evergreen-ci/lru
   version: d1b427740b3b78780272eb34942e4ed27e0e101d
 

--- a/repobuilder/job.go
+++ b/repobuilder/job.go
@@ -271,7 +271,7 @@ func (j *repoBuilderJob) linkPackages(dest string) error {
 		}
 
 		mirror := filepath.Join(dest, filepath.Base(pkg))
-		if j.release.IsDevelopmentBuild() || j.release.IsContinuous() {
+		if j.release.IsDevelopmentBuild() || (j.release.IsLTS() && j.release.IsDevelopmentSeries()) || j.release.IsContinuous() {
 			new := strings.Replace(mirror, j.release.String(), j.release.Series(), 1)
 			if new != mirror {
 				grip.Debug(message.Fields{

--- a/repobuilder/job.go
+++ b/repobuilder/job.go
@@ -53,7 +53,7 @@ type repoBuilderJob struct {
 	tmpdir      string
 	client      *http.Client
 	workingDirs []string
-	release     *bond.MongoDBVersion
+	release     bond.MongoDBVersion
 	builder     jobImpl
 }
 
@@ -112,7 +112,7 @@ type JobOptions struct {
 	NotaryKey   string `bson:"notary_key" json:"notary_key" yaml:"notary_key"`
 	NotaryToken string `bson:"notary_token" json:"notary_token" yaml:"notary_token"`
 
-	release *bond.MongoDBVersion
+	release bond.MongoDBVersion
 }
 
 // Validate returns an error if the job options struct is not
@@ -122,7 +122,7 @@ func (opts *JobOptions) Validate() error {
 	catcher.NewWhen(opts.Configuration == nil, "configuration must not be nil")
 	catcher.NewWhen(opts.Distro == nil, "distro specification must not be nil")
 
-	release, err := bond.NewMongoDBVersion(opts.Version)
+	release, err := bond.CreateMongoDBVersion(opts.Version)
 	catcher.Add(err)
 	opts.release = release
 
@@ -205,7 +205,7 @@ func (j *repoBuilderJob) setup() {
 	var err error
 
 	if j.release == nil {
-		j.release, err = bond.NewMongoDBVersion(j.Version)
+		j.release, err = bond.CreateMongoDBVersion(j.Version)
 		if err != nil {
 			j.AddError(err)
 		}
@@ -223,6 +223,7 @@ func (j *repoBuilderJob) setup() {
 				j.NotaryKey = "richard"
 				j.NotaryToken = os.Getenv("NOTARY_TOKEN_DEB_LEGACY")
 			} else {
+				// TODO: maybe need to change this.
 				j.NotaryKey = "server-" + j.release.StableReleaseSeries()
 			}
 		}
@@ -269,7 +270,7 @@ func (j *repoBuilderJob) linkPackages(dest string) error {
 		}
 
 		mirror := filepath.Join(dest, filepath.Base(pkg))
-		if j.release.IsDevelopmentBuild() {
+		if j.release.IsDevelopmentBuild() || !j.release.IsLTS() {
 			new := strings.Replace(mirror, j.release.String(), j.release.Series(), 1)
 			if new != mirror {
 				grip.Debug(message.Fields{
@@ -327,14 +328,14 @@ func (j *repoBuilderJob) injectNewPackages(local string) (string, error) {
 }
 
 func (j *repoBuilderJob) getPackageLocation() string {
-	if j.release.IsDevelopmentBuild() {
-		// nightlies to the a "development" repo.
-		return "development"
-	} else if j.release.IsReleaseCandidate() {
-		// release candidates go into the testing repo:
+	if j.release.IsReleaseCandidate() {
+		// release candidates go into the testing repo.
 		return "testing"
+	} else if j.release.IsDevelopmentBuild() || j.release.IsContinuous() {
+		// nightlies and continuous releases to the a "development" repo.
+		return "development"
 	} else {
-		// there are repos for each series:
+		// stable releases and LTS releases have their own repos.
 		return j.release.Series()
 	}
 }

--- a/repobuilder/job.go
+++ b/repobuilder/job.go
@@ -222,8 +222,9 @@ func (j *repoBuilderJob) setup() {
 			if j.Distro.Type == DEB && (j.release.Series() == "3.0" || j.release.Series() == "2.6") {
 				j.NotaryKey = "richard"
 				j.NotaryToken = os.Getenv("NOTARY_TOKEN_DEB_LEGACY")
+			} else if j.release.IsLTS() || j.release.IsContinuous() {
+				j.NotaryKey = "server-" + j.release.Series()
 			} else {
-				// TODO: maybe need to change this.
 				j.NotaryKey = "server-" + j.release.StableReleaseSeries()
 			}
 		}
@@ -331,8 +332,8 @@ func (j *repoBuilderJob) getPackageLocation() string {
 	if j.release.IsReleaseCandidate() {
 		// release candidates go into the testing repo.
 		return "testing"
-	} else if j.release.IsDevelopmentBuild() || j.release.IsContinuous() {
-		// nightlies and continuous releases to the a "development" repo.
+	} else if j.release.IsDevelopmentBuild() || (j.release.IsLTS() && j.release.IsDevelopmentRelease()) || j.release.IsContinuous() {
+		// nightlies and continuous releases go into the "development" repo.
 		return "development"
 	} else {
 		// stable releases and LTS releases have their own repos.

--- a/repobuilder/job.go
+++ b/repobuilder/job.go
@@ -270,7 +270,7 @@ func (j *repoBuilderJob) linkPackages(dest string) error {
 		}
 
 		mirror := filepath.Join(dest, filepath.Base(pkg))
-		if j.release.IsDevelopmentBuild() || !j.release.IsLTS() {
+		if j.release.IsDevelopmentBuild() || j.release.IsContinuous() {
 			new := strings.Replace(mirror, j.release.String(), j.release.Series(), 1)
 			if new != mirror {
 				grip.Debug(message.Fields{

--- a/repobuilder/job_test.go
+++ b/repobuilder/job_test.go
@@ -106,8 +106,13 @@ func TestGetPackageLocation(t *testing.T) {
 			expectedLocation: "testing",
 		},
 		{
-			name:             "NewDevelopmentRelease",
+			name:             "NewDevelopmentReleaseLTS",
 			version:          "5.0.5-alpha1",
+			expectedLocation: "development",
+		},
+		{
+			name:             "NewDevelopmentReleaseQuarterly",
+			version:          "5.2.5-alpha1",
 			expectedLocation: "development",
 		},
 		{

--- a/repobuilder/job_test.go
+++ b/repobuilder/job_test.go
@@ -61,7 +61,7 @@ func TestProcessPackages(t *testing.T) {
 
 	j := buildRepoJob()
 	var err error
-	j.release, err = bond.NewMongoDBVersion("4.2.5-rc1")
+	j.release, err = bond.CreateMongoDBVersion("4.2.5-rc1")
 	require.NoError(t, err)
 	j.client = utility.GetDefaultHTTPRetryableClient()
 	j.Distro = &RepositoryDefinition{Name: "test"}
@@ -72,4 +72,61 @@ func TestProcessPackages(t *testing.T) {
 
 	assert.NoError(t, j.processPackages(ctx))
 	assert.Len(t, j.PackagePaths, 6)
+}
+
+func TestGetPackageLocation(t *testing.T) {
+	for _, test := range []struct {
+		name             string
+		version          string
+		expectedLocation string
+	}{
+		{
+			name:             "LegacyReleaseCandidate",
+			version:          "4.2.5-rc1",
+			expectedLocation: "testing",
+		},
+		{
+			name:             "LegacyDevelopmentBuild",
+			version:          "4.2.5-pre-",
+			expectedLocation: "development",
+		},
+		{
+			name:             "LegacyDevelopmentSeries",
+			version:          "4.2.5",
+			expectedLocation: "4.2",
+		},
+		{
+			name:             "LegacyProductionSeries",
+			version:          "4.1.5",
+			expectedLocation: "4.1",
+		},
+		{
+			name:             "NewReleaseCandidate",
+			version:          "5.3.5-rc1",
+			expectedLocation: "testing",
+		},
+		{
+			name:             "NewDevelopmentBuild",
+			version:          "5.0.5-alpha1",
+			expectedLocation: "development",
+		},
+		{
+			name:             "NewQuarterly",
+			version:          "5.3.5",
+			expectedLocation: "development",
+		},
+		{
+			name:             "NewLTS",
+			version:          "5.0.5",
+			expectedLocation: "5.0",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			var err error
+			j := buildRepoJob()
+			j.release, err = bond.CreateMongoDBVersion(test.version)
+			require.NoError(t, err)
+			assert.Equal(t, test.expectedLocation, j.getPackageLocation())
+		})
+	}
 }

--- a/repobuilder/job_test.go
+++ b/repobuilder/job_test.go
@@ -87,18 +87,18 @@ func TestGetPackageLocation(t *testing.T) {
 		},
 		{
 			name:             "LegacyDevelopmentBuild",
-			version:          "4.2.5-pre-",
+			version:          "4.1.5-pre-",
 			expectedLocation: "development",
 		},
 		{
 			name:             "LegacyDevelopmentSeries",
-			version:          "4.2.5",
-			expectedLocation: "4.2",
+			version:          "4.1.5",
+			expectedLocation: "4.1",
 		},
 		{
 			name:             "LegacyProductionSeries",
-			version:          "4.1.5",
-			expectedLocation: "4.1",
+			version:          "4.2.5",
+			expectedLocation: "4.2",
 		},
 		{
 			name:             "NewReleaseCandidate",
@@ -106,7 +106,7 @@ func TestGetPackageLocation(t *testing.T) {
 			expectedLocation: "testing",
 		},
 		{
-			name:             "NewDevelopmentBuild",
+			name:             "NewDevelopmentRelease",
 			version:          "5.0.5-alpha1",
 			expectedLocation: "development",
 		},

--- a/vendor/github.com/evergreen-ci/bond/catalog.go
+++ b/vendor/github.com/evergreen-ci/bond/catalog.go
@@ -169,11 +169,11 @@ func (c *BuildCatalog) Get(version, edition, target, arch string, debug bool) (s
 			// targets are "osx". However, starting in 4.1.1, OSX targets are
 			// "macos".
 			if runtime.GOOS == "darwin" {
-				parsedVersion, err := NewMongoDBVersion(version)
+				parsedVersion, err := CreateMongoDBVersion(version)
 				if err != nil {
 					return "", errors.Wrap(err, "could not parse version")
 				}
-				macosVersion, err := NewMongoDBVersion("4.1.1")
+				macosVersion, err := CreateMongoDBVersion("4.1.1")
 				if err != nil {
 					return "", errors.Wrap(err, "could not parse version for comparison")
 				}

--- a/vendor/github.com/evergreen-ci/bond/feed.go
+++ b/vendor/github.com/evergreen-ci/bond/feed.go
@@ -73,7 +73,7 @@ func NewArtifactsFeed(path string) (*ArtifactsFeed, error) {
 		// if the thing we think should be the json file
 		// exists but isn't a file (i.e. directory,) then this
 		// should be an error.
-		return nil, errors.Errorf("path %s not a json file  directory", path)
+		return nil, errors.Errorf("path %s not a json file directory", path)
 	}
 
 	return f, nil
@@ -109,7 +109,6 @@ func (feed *ArtifactsFeed) Reload(data []byte) error {
 		return errors.Wrap(err, "problem converting data from json")
 	}
 
-	// this is a reload rather than a new load, and we shoiuld
 	if len(feed.table) > 0 {
 		feed.table = make(map[string]*ArtifactVersion)
 	}

--- a/vendor/github.com/evergreen-ci/bond/fetch.go
+++ b/vendor/github.com/evergreen-ci/bond/fetch.go
@@ -30,7 +30,7 @@ func createDirectory(path string) error {
 }
 
 // CacheDownload downloads a resource (url) into a file (path); if the
-// file already exists CaceheDownlod does not download a new copy of
+// file already exists CacheDownload does not download a new copy of
 // the file, unless local file is older than the ttl, or the force
 // option is specified. CacheDownload returns the contents of the file.
 func CacheDownload(ctx context.Context, ttl time.Duration, url, path string, force bool) ([]byte, error) {

--- a/vendor/github.com/evergreen-ci/bond/version.go
+++ b/vendor/github.com/evergreen-ci/bond/version.go
@@ -10,7 +10,7 @@ import (
 
 // ArtifactVersion represents a document in the Version field of the
 // MongoDB build information feed. See
-// http://downloads.mongodb.org/full.json for an example.ownload
+// http://downloads.mongodb.org/full.json for an example download
 type ArtifactVersion struct {
 	Version   string
 	Downloads []ArtifactDownload
@@ -41,7 +41,7 @@ func (version *ArtifactVersion) GetDownload(key BuildOptions) (ArtifactDownload,
 	version.mutex.RLock()
 	defer version.mutex.RLock()
 
-	// TODO: this is the place to fix hanlding for the Base edition, which is not necessarily intuitive.
+	// TODO: this is the place to fix handling for the Base edition, which is not necessarily intuitive.
 	if key.Edition == Base {
 		if key.Target == "linux" {
 			key.Target += "_" + string(key.Arch)
@@ -51,11 +51,11 @@ func (version *ArtifactVersion) GetDownload(key BuildOptions) (ArtifactDownload,
 	// For OSX, the target depends on the version. Before 4.1, OSX targets are
 	// "osx". However, starting in 4.1.1, OSX targets are "macos".
 	if key.Target == "osx" {
-		parsedVersion, err := NewMongoDBVersion(version.Version)
+		parsedVersion, err := CreateMongoDBVersion(version.Version)
 		if err != nil {
 			return ArtifactDownload{}, errors.Wrap(err, "could not parse version")
 		}
-		macosVersion, err := NewMongoDBVersion("4.1.1")
+		macosVersion, err := CreateMongoDBVersion("4.1.1")
 		if err != nil {
 			return ArtifactDownload{}, errors.Wrap(err, "could not parse version for comparison")
 		}

--- a/vendor/github.com/evergreen-ci/bond/versions.go
+++ b/vendor/github.com/evergreen-ci/bond/versions.go
@@ -9,6 +9,7 @@ package bond
 
 import (
 	"fmt"
+	"github.com/pkg/errors"
 	"sort"
 	"strconv"
 	"strings"
@@ -16,11 +17,61 @@ import (
 	"github.com/blang/semver"
 )
 
-// MongoDBVersion is a structure representing a version identifier for
-// MongoDB. Use the associated methods to ask questions about MongoDB
+const (
+	endOfLegacy = "4.5.0-alpha0"
+	devReleaseTag = "alpha"
+)
+
+// MongoDBVersion encapsulates information about a MongoDB version.
+// Use the associated methods to ask questions about MongoDB
 // versions. All parsing of versions happens during construction, and
-// individual method calls are very light-weight.
-type MongoDBVersion struct {
+// individual method calls are very light-weight. Note that
+// not all methods are applicable for all versions.
+type MongoDBVersion interface {
+	// String returns a string representation of the MongoDB version number.
+	String() string
+	// Parsed returns the parsed version object for the version.
+	Parsed() semver.Version
+	// Series returns the first two components for the version.
+	Series() string
+	// IsReleaseCandidate returns true if the version is a release candidate.
+	IsReleaseCandidate() bool
+	// IsDevelopmentRelease returns true if the version is a development release.
+	IsDevelopmentRelease() bool
+	// DevelopmentReleaseNumber returns the development release number, if applicable.
+	DevelopmentReleaseNumber() int
+	// RCNumber returns the RC counter (or -1 if not a release candidate).
+	RCNumber() int
+	// IsLTS returns true if the release is long-term supported, i.e. the yearly release.
+	IsLTS() bool
+	// IsContinuous returns true if the release is a quarterly (non-LTS) release.
+	IsContinuous() bool
+	// IsRelease returns true if the version is a release.
+	IsRelease() bool
+	// IsDevelopmentBuild returns true for non-release versions.
+	IsDevelopmentBuild() bool
+	// IsStableSeries returns true if the legacy version is a stable series.
+	IsStableSeries() bool
+	// IsDevelopmentSeries returns true if the legacy version is a development series.
+	IsDevelopmentSeries() bool
+	// StableReleaseSeries returns true if the legacy version is a stable release series.
+	StableReleaseSeries() string
+	// IsInitialStableReleaseCandidate returns true if the legacy version is a release
+	// candidate for the initial release of a stable series.
+	IsInitialStableReleaseCandidate() bool
+
+	IsLessThan(version MongoDBVersion) bool
+	IsLessThanOrEqualTo(version MongoDBVersion) bool
+	IsGreaterThan(version MongoDBVersion) bool
+	IsGreaterThanOrEqualTo(version MongoDBVersion) bool
+	IsEqualTo(version MongoDBVersion) bool
+	IsNotEqualTo(version MongoDBVersion) bool
+
+}
+
+// LegacyMongoDBVersion is a structure representing a version identifier for legacy versions of
+// MongoDB, which implements the MongoDBVersion interface.
+type LegacyMongoDBVersion struct {
 	source   string
 	parsed   semver.Version
 	isRc     bool
@@ -30,13 +81,99 @@ type MongoDBVersion struct {
 	tag      string
 }
 
-// NewMongoDBVersion takes a string representing a MongoDB version and
-// returns a MongoDBVersion object. If the input string is not a valid
-// version, or there were problems parsing the string, the error value
-// is non-nil. All parsing of a version happens during this phase.
-func NewMongoDBVersion(version string) (*MongoDBVersion, error) {
-	v := &MongoDBVersion{source: version, rcNumber: -1}
+// NewMongoDBVersion is a structure representing a version identifier for versions of
+// MongoDB, which implements the MongoDBVersion.
+type NewMongoDBVersion struct {
+	LegacyMongoDBVersion // note not all fields are applicable to NewMongoDBVersion
+	isDevRelease bool
+	devReleaseNumber int
+	quarter string
+}
 
+// IsStableSeries is not applicable to new versions, so always return false.
+func (v *NewMongoDBVersion) IsStableSeries() bool {
+	return false
+}
+
+// IsDevelopmentSeries is not applicable to new versions, so always return false.
+func (v *NewMongoDBVersion) IsDevelopmentSeries() bool {
+	return false
+}
+
+// IsInitialStableReleaseCandidate is not applicable to new versions, so always return false.
+func (v *NewMongoDBVersion) IsInitialStableReleaseCandidate() bool {
+	return false
+}
+
+// StableReleaseSeries is not applicable to new versions, so always return the empty string.
+func (v *NewMongoDBVersion) StableReleaseSeries() string {
+	return ""
+}
+
+// Series returns the major and quarter for the version.
+func (v *NewMongoDBVersion) Series() string {
+	return v.series
+}
+
+// IsLTS returns true if this is the first release of the year.
+func (v *NewMongoDBVersion) IsLTS() bool {
+	return v.IsRelease() && v.Parsed().Minor == 0
+}
+
+// func IsContinuous returns true if the version is a continuous release.
+func (v *NewMongoDBVersion) IsContinuous() bool {
+	return v.IsRelease() && v.Parsed().Minor != 0
+}
+
+// IsDevelopmentRelease returns true if the version is a development release.
+func (v *NewMongoDBVersion) IsDevelopmentRelease() bool {
+	return v.isDevRelease
+}
+
+// DevelopmentReleaseNumber returns the number of the development release,
+// or -1 if not applicable.
+func (v *NewMongoDBVersion) DevelopmentReleaseNumber() int {
+	return v.devReleaseNumber
+}
+
+// CreateMongoDBVersion returns an implementation of the MongoDBVersion.
+// If the parsed version is before 4.5.0, then we use the legacy structure.
+// Otherwise, we use the modern versioning scheme.
+func CreateMongoDBVersion(version string) (MongoDBVersion, error) {
+	endOfLegacyVersion, _ := semver.Parse(endOfLegacy)
+	v, err := createLegacyMongoDBVersion(version)
+	if err != nil {
+		return nil, errors.Wrapf(err, "creating initial version")
+	}
+	if v.Parsed().LT(endOfLegacyVersion) {
+		return v, nil
+	}
+	return createNewMongoDBVersion(*v)
+}
+
+// createNewMongoDBVersion takes a string representing a MongoDBVersion and
+// returns a NewMongoDBVersion object. All parsing of a version happens during this phase.
+func createNewMongoDBVersion(parsedVersion LegacyMongoDBVersion) (*NewMongoDBVersion, error) {
+	v := &NewMongoDBVersion{LegacyMongoDBVersion: parsedVersion, devReleaseNumber: -1}
+	var err error
+	if len(v.String()) < 3 {
+		return nil, errors.Errorf("version '%s' is invalid", v.String())
+	}
+	v.quarter = v.String()[:3]
+	if strings.Contains(v.tag, devReleaseTag) {
+		v.isDevRelease = true
+		v.devReleaseNumber, err = strconv.Atoi(v.tag[len(devReleaseTag):])
+		if err != nil {
+			return nil, errors.Wrapf(err, "couldn't parse development release number")
+		}
+	}
+	return v, err
+}
+
+// createLegacyMongoDBVersion takes a string representing a MongoDB version and
+// returns a LegacyMongoDBVersion object. All parsing of a version happens during this phase.
+func createLegacyMongoDBVersion(version string) (*LegacyMongoDBVersion, error) {
+	v := &LegacyMongoDBVersion{source: version, rcNumber: -1}
 	if strings.HasSuffix(version, "-") {
 		v.isDev = true
 
@@ -54,7 +191,7 @@ func NewMongoDBVersion(version string) (*MongoDBVersion, error) {
 
 	parsed, err := semver.Parse(version)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "error parsing '%s'", version)
 	}
 	v.parsed = parsed
 
@@ -71,6 +208,9 @@ func NewMongoDBVersion(version string) (*MongoDBVersion, error) {
 			rcPart := strings.Split(tagParts[1], "+")
 
 			v.rcNumber, err = strconv.Atoi(rcPart[0][2:])
+			if err != nil {
+				return nil, errors.Wrapf(err, "couldn't parse release candidate number")
+			}
 			if len(tagParts) > 2 {
 				v.isDev = true
 			}
@@ -79,54 +219,66 @@ func NewMongoDBVersion(version string) (*MongoDBVersion, error) {
 		}
 
 	}
-
-	v.series = version[:3]
+	if len(version) < 3 {
+		return nil, errors.Errorf("version '%s' is invalid", version)
+	}
+	v.series = fmt.Sprintf("%d.%d", v.Parsed().Major, v.Parsed().Minor)
 	return v, err
 }
 
 // ConvertVersion takes an un-typed object and attempts to convert it to a
 // version object. For use with compactor functions.
-func ConvertVersion(v interface{}) (*MongoDBVersion, error) {
+func ConvertVersion(v interface{}) (MongoDBVersion, error) {
 	switch version := v.(type) {
-	case *MongoDBVersion:
+	case *LegacyMongoDBVersion:
 		return version, nil
-	case MongoDBVersion:
+	case LegacyMongoDBVersion:
 		return &version, nil
+	case *NewMongoDBVersion:
+		return version, nil
+	case NewMongoDBVersion:
+		return &version, nil
+	case MongoDBVersion:
+		return version, nil
 	case string:
-		output, err := NewMongoDBVersion(version)
+		output, err := CreateMongoDBVersion(version)
 		if err != nil {
 			return nil, err
 		}
 		return output, nil
 	case semver.Version:
-		return NewMongoDBVersion(version.String())
+		return CreateMongoDBVersion(version.String())
 	default:
 		return nil, fmt.Errorf("%v is not a valid version type (%T)", version, version)
 	}
 }
 
-// String returns a string representation of the MongoDB version
-// number.
-func (v *MongoDBVersion) String() string {
+// String returns a string representation of the MongoDB version number.
+func (v *LegacyMongoDBVersion) String() string {
 	return v.source
+}
+
+// Parsed returns the parsed version object for the version.
+func (v *LegacyMongoDBVersion) Parsed() semver.Version {
+	return v.parsed
 }
 
 // Series return the release series, generally the first two
 // components of a version. For example for 3.2.6, the series is 3.2.
-func (v *MongoDBVersion) Series() string {
+func (v *LegacyMongoDBVersion) Series() string {
 	return v.series
 }
 
 // IsReleaseCandidate returns true for releases that have the "rc[0-9]"
 // tag and false otherwise.
-func (v *MongoDBVersion) IsReleaseCandidate() bool {
+func (v *LegacyMongoDBVersion) IsReleaseCandidate() bool {
 	return v.IsRelease() && v.isRc
 }
 
 // IsStableSeries returns true for stable releases, ones where the
 // second component of the version string (i.e. "Minor" in semantic
 // versioning terms) are even, and false otherwise.
-func (v *MongoDBVersion) IsStableSeries() bool {
+func (v *LegacyMongoDBVersion) IsStableSeries() bool {
 	return v.parsed.Minor%2 == 0
 }
 
@@ -134,7 +286,7 @@ func (v *MongoDBVersion) IsStableSeries() bool {
 // releases. These versions are those where the second component
 // (e.g. "Minor" in semantic versioning terms) are odd, and false
 // otherwise.
-func (v *MongoDBVersion) IsDevelopmentSeries() bool {
+func (v *LegacyMongoDBVersion) IsDevelopmentSeries() bool {
 	return !v.IsStableSeries()
 }
 
@@ -142,7 +294,7 @@ func (v *MongoDBVersion) IsDevelopmentSeries() bool {
 // version. For stable releases, the output is the same as
 // .Series(). For development releases, this method returns the *next*
 // stable series.
-func (v *MongoDBVersion) StableReleaseSeries() string {
+func (v *LegacyMongoDBVersion) StableReleaseSeries() string {
 	if v.IsStableSeries() {
 		return v.Series()
 	}
@@ -159,76 +311,96 @@ func (v *MongoDBVersion) StableReleaseSeries() string {
 // and false otherwise. Other builds, including test builds and
 // "nightly" snapshots of MongoDB have version strings, but are not
 // releases.
-func (v *MongoDBVersion) IsRelease() bool {
+func (v *LegacyMongoDBVersion) IsRelease() bool {
 	return !v.isDev
+}
+
+// IsLTS isn't applicable to legacy versions so we return false.
+func (v *LegacyMongoDBVersion) IsLTS() bool {
+	return false
+}
+
+// IsContinuous isn't applicable to legacy versions so return false.
+func (v *LegacyMongoDBVersion) IsContinuous() bool {
+	return false
+}
+
+// IsDevelopmentRelease returns true if the version refers to a development release.
+func (v *LegacyMongoDBVersion) IsDevelopmentRelease() bool {
+	return v.IsDevelopmentSeries() && v.IsRelease()
+}
+
+// DevelopmentReleaseNumber is not applicable to legacy versions, so it returns -1.
+func (v *LegacyMongoDBVersion) DevelopmentReleaseNumber() int {
+	return -1
 }
 
 // IsDevelopmentBuild returns true for all non-release builds,
 // including nightly snapshots and all testing and development
 // builds.
-func (v *MongoDBVersion) IsDevelopmentBuild() bool {
+func (v *LegacyMongoDBVersion) IsDevelopmentBuild() bool {
 	return v.isDev
 }
 
 // IsInitialStableReleaseCandidate returns true for release
 // candidates for the initial public release of a new stable release
 // series.
-func (v *MongoDBVersion) IsInitialStableReleaseCandidate() bool {
+func (v *LegacyMongoDBVersion) IsInitialStableReleaseCandidate() bool {
 	if v.IsStableSeries() {
 		return v.parsed.Patch == 0 && v.IsReleaseCandidate()
 	}
 	return false
 }
 
-// RcNumber returns an integer for the RC counter. For non-rc releases,
+// RCNumber returns an integer for the RC counter. For non-rc releases,
 // returns -1.
-func (v *MongoDBVersion) RcNumber() int {
+func (v *LegacyMongoDBVersion) RCNumber() int {
 	return v.rcNumber
 }
 
 // IsLessThan returns true when "version" is less than (e.g. earlier)
 // than the object itself.
-func (v *MongoDBVersion) IsLessThan(version *MongoDBVersion) bool {
-	return v.parsed.LT(version.parsed)
+func (v *LegacyMongoDBVersion) IsLessThan(version MongoDBVersion) bool {
+	return v.Parsed().LT(version.Parsed())
 }
 
 // IsLessThanOrEqualTo returns true when "version" is less than or
 // equal to (e.g. earlier or the same as) the object itself.
-func (v *MongoDBVersion) IsLessThanOrEqualTo(version *MongoDBVersion) bool {
+func (v *LegacyMongoDBVersion) IsLessThanOrEqualTo(version MongoDBVersion) bool {
 	// semver considers release candidates equal to GA, so we have to special case this
 
 	if v.IsEqualTo(version) {
 		return true
 	}
 
-	return v.parsed.LT(version.parsed)
+	return v.Parsed().LT(version.Parsed())
 }
 
 // IsGreaterThan returns true when "version" is greater than (e.g. later)
 // than the object itself.
-func (v *MongoDBVersion) IsGreaterThan(version *MongoDBVersion) bool {
-	return v.parsed.GT(version.parsed)
+func (v *LegacyMongoDBVersion) IsGreaterThan(version MongoDBVersion) bool {
+	return v.Parsed().GT(version.Parsed())
 }
 
 // IsGreaterThanOrEqualTo returns true when "version" is greater than
 // or equal to (e.g. the same as or later than) the object itself.
-func (v *MongoDBVersion) IsGreaterThanOrEqualTo(version *MongoDBVersion) bool {
+func (v *LegacyMongoDBVersion) IsGreaterThanOrEqualTo(version MongoDBVersion) bool {
 	if v.IsEqualTo(version) {
 		return true
 	}
-	return v.parsed.GT(version.parsed)
+	return v.Parsed().GT(version.Parsed())
 }
 
 // IsEqualTo returns true when "version" is the same as the object
 // itself.
-func (v *MongoDBVersion) IsEqualTo(version *MongoDBVersion) bool {
-	return v.source == version.source
+func (v *LegacyMongoDBVersion) IsEqualTo(version MongoDBVersion) bool {
+	return v.String() == version.String()
 }
 
 // IsNotEqualTo returns true when "version" is the different from the
 // object itself.
-func (v *MongoDBVersion) IsNotEqualTo(version *MongoDBVersion) bool {
-	return v.source != version.source
+func (v *LegacyMongoDBVersion) IsNotEqualTo(version MongoDBVersion) bool {
+	return v.String() != version.String()
 }
 
 /////////////////////////////////////////////
@@ -254,7 +426,7 @@ func (s MongoDBVersionSlice) Less(i, j int) bool {
 	left := s[i]
 	right := s[j]
 
-	return left.parsed.LT(right.parsed)
+	return left.Parsed().LT(right.Parsed())
 }
 
 // Swap is a required by the sort.Sorter interface. Changes the
@@ -270,12 +442,12 @@ func (s MongoDBVersionSlice) String() string {
 	var out []string
 
 	for _, v := range s {
-		if len(v.source) == 0 {
+		if len(v.String()) == 0 {
 			// some elements end up empty.
 			continue
 		}
 
-		out = append(out, v.source)
+		out = append(out, v.String())
 	}
 
 	return strings.Join(out, ", ")


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12672

This revendors bond and updates the `getPackageLocation` in the repobuilder job. Old releases will continue to go to the same repos, new releases will go to the following:
release candidates -> `testing`
quarterly and dev releases -> `development`
LTS -> `<series>` ex: `5.2`