### PR TITLE
EVG-14544: fix incorrect bool arg for splunk command

### DIFF
--- a/operations/splunk.go
+++ b/operations/splunk.go
@@ -36,7 +36,7 @@ func Splunk() cli.Command {
 				Usage:  "",
 				EnvVar: "GRIP_SPLUNK_CHANNEL",
 			},
-			cli.StringFlag{
+			cli.BoolFlag{
 				Name:  "json",
 				Usage: "when specified, all input is parsed as new-line separated json",
 			},


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14544

Fix the flag type on the splunk command.