### PR TITLE
EVG-14950: log Splunk messages at the threshold level

### DIFF
--- a/operations/buildlogger.go
+++ b/operations/buildlogger.go
@@ -337,7 +337,7 @@ func (l *cmdLogger) runCommand(cmd *exec.Cmd) error {
 }
 
 func (l *cmdLogger) readPipe(pipe io.Reader) error {
-	lvl := l.logger.GetSender().Level().Default
+	lvl := l.logger.GetSender().Level().Threshold
 	input := bufio.NewScanner(pipe)
 	for input.Scan() {
 		l.logLine(input.Bytes(), lvl)
@@ -347,7 +347,7 @@ func (l *cmdLogger) readPipe(pipe io.Reader) error {
 }
 
 func (l *cmdLogger) followFile(fn string) error {
-	lvl := l.logger.GetSender().Level().Default
+	lvl := l.logger.GetSender().Level().Threshold
 	tail, err := follower.New(fn, follower.Config{Reopen: true})
 	if err != nil {
 		return errors.Wrapf(err, "problem setting up file follower of '%s'", fn)


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-14950

For some reason, `curator splunk command` uses the global grip sender's threshold log level when deciding to log to Splunk, but `curator splunk follow` and `curator splunk pipe` use the default log level. This is problematic because you can't modify the global sender's default log level, only the threshold. Since the default log level is 20 (trace) and the unconfigured threshold log level is 40 (info), it'll never log the `follow` or `pipe` output to splunk unless you use `curator --level trace`, which is undesirable.

I changed the two to log at the threshold level instead of the default level to ensure they get logged, which seems reasonable since the whole point of the two commands is to log all the input to Splunk.