### PR TITLE
EVG-15628: fix up evergreen YAML

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -106,9 +106,6 @@ tasks:
   # define tasks for all test suites (modules)
   - <<: *run-go-test-suite
     tags: ["test"]
-    name: test-barquesubmit
-  - <<: *run-go-test-suite
-    tags: ["test"]
     name: test-greenbay
   - <<: *run-go-test-suite
     tags: ["test"]
@@ -147,12 +144,6 @@ post:
     params:
       files:
         - "curator/build/output.*"
-  - command: shell.exec
-    type: setup
-    params:
-      script: |
-        rm -rf curator
-        rm -rf ~/.aws
   - command: s3.put
     type: system
     params:
@@ -205,6 +196,7 @@ buildvariants:
   - name: rhel70
     display_name: RHEL 7.0
     expansions:
+      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       goarch: amd64
       goos: linux
@@ -222,6 +214,7 @@ buildvariants:
       - ubuntu1804-small
       - ubuntu1804-large
     expansions:
+      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       goarch: amd64
       goos: linux
@@ -264,6 +257,7 @@ buildvariants:
   - name: s390x
     display_name: "zLinux (cross-compile)"
     expansions:
+      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       goarch: s390x
       goos: linux
@@ -280,6 +274,7 @@ buildvariants:
   - name: power
     display_name: "Linux POWER (cross-compile)"
     expansions:
+      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       goarch: ppc64le
       goos: linux
@@ -296,6 +291,7 @@ buildvariants:
   - name: arm
     display_name: "Linux ARM64 (cross-compile)"
     expansions:
+      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       goarch: arm64
       goos: linux
@@ -312,6 +308,7 @@ buildvariants:
   - name: linux-32
     display_name: "Linux 32-bit (cross-compile)"
     expansions:
+      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       goarch: 386
       goos: linux
@@ -328,6 +325,7 @@ buildvariants:
   - name: windows-64
     display_name: "Windows 64-bit (cross-compile)"
     expansions:
+      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       goarch: amd64
       goos: windows
@@ -344,6 +342,7 @@ buildvariants:
   - name: windows-32
     display_name: "Windows 32-bit (cross-compile)"
     expansions:
+      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       goarch: 386
       goos: windows


### PR DESCRIPTION
I looked over the tests and noticed a couple of small fixes, of which only the first bullet point is related to #159.

* Do not run `test-barquesubmit` in CI tests since barquesubmit has no tests.
* Remove random unneeded `rm -rf` from post commands.
* Use `DISABLE_COVERAGE` for all build variants except.