### PR TITLE
EVG-15682: remove DISABLE_COVERAGE flag

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -111,7 +111,7 @@ tasks:
 
   - <<: *run-build
     tags: ["report"]
-    name: coverage-html
+    name: html-coverage
 
   # define tasks for all test suites (modules)
   - <<: *run-go-test-suite

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -51,7 +51,7 @@ functions:
       working_dir: curator
       binary: make
       args: ["${target}"]
-      include_expansions_in_env: ["DISABLE_COVERAGE", "GOROOT", "RACE_DETECTOR"]
+      include_expansions_in_env: ["GOROOT", "RACE_DETECTOR"]
       env:
         GOOS: ${goos}
         GOARCH: ${goarch}
@@ -184,7 +184,6 @@ buildvariants:
   - name: race-detector
     display_name: Race Detector (Arch Linux)
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       RACE_DETECTOR: true
     run_on:
@@ -206,7 +205,6 @@ buildvariants:
   - name: rhel70
     display_name: RHEL 7.0
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       goarch: amd64
       goos: linux
@@ -224,7 +222,6 @@ buildvariants:
       - ubuntu1804-small
       - ubuntu1804-large
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       goarch: amd64
       goos: linux
@@ -236,7 +233,6 @@ buildvariants:
   - name: macos
     display_name: macOS 10.14
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       goarch: amd64
       goos: darwin
@@ -251,7 +247,6 @@ buildvariants:
   - name: macos-arm64
     display_name: macOS 11.00 ARM64 (cross-compile)
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       goarch: arm64
       goos: darwin
@@ -267,7 +262,6 @@ buildvariants:
   - name: s390x
     display_name: "zLinux (cross-compile)"
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       goarch: s390x
       goos: linux
@@ -284,7 +278,6 @@ buildvariants:
   - name: power
     display_name: "Linux POWER (cross-compile)"
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       goarch: ppc64le
       goos: linux
@@ -301,7 +294,6 @@ buildvariants:
   - name: arm
     display_name: "Linux ARM64 (cross-compile)"
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       goarch: arm64
       goos: linux
@@ -318,7 +310,6 @@ buildvariants:
   - name: linux-32
     display_name: "Linux 32-bit (cross-compile)"
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       goarch: 386
       goos: linux
@@ -335,7 +326,6 @@ buildvariants:
   - name: windows-64
     display_name: "Windows 64-bit (cross-compile)"
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       goarch: amd64
       goos: windows
@@ -352,7 +342,6 @@ buildvariants:
   - name: windows-32
     display_name: "Windows 32-bit (cross-compile)"
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       goarch: 386
       goos: windows

--- a/makefile
+++ b/makefile
@@ -77,8 +77,8 @@ $(buildDir)/run-linter: cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 lintOutput := $(foreach target,$(allPackages),$(buildDir)/output.$(target).lint)
 testOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(target).test)
 coverageOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(target).coverage)
-coverageHtmlOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(target).coverage.html)
-.PRECIOUS: $(testOutput) $(lintOutput) $(coverageOutput) $(coverageHtmlOutput)
+htmlCoverageOutput := $(foreach target,$(testPackages),$(buildDir)/output.$(target).coverage.html)
+.PRECIOUS: $(testOutput) $(lintOutput) $(coverageOutput) $(htmlCoverageOutput)
 # end output files
 
 # start basic development operations
@@ -87,8 +87,8 @@ compile:
 test: $(testOutput)
 lint: $(lintOutput)
 coverage: $(coverageOutput)
-coverage-html: $(coverageHtmlOutput)
-phony := compile lint test coverage coverage-html
+html-coverage: $(htmlCoverageOutput)
+phony := compile lint test coverage html-coverage
 
 # start convenience targets for running tests and coverage tasks on a
 # specific package.

--- a/makefile
+++ b/makefile
@@ -111,9 +111,6 @@ endif
 ifneq (,$(RUN_COUNT))
 testArgs += -count=$(RUN_COUNT)
 endif
-ifeq (,$(DISABLE_COVERAGE))
-testArgs += -cover
-endif
 ifneq (,$(RACE_DETECTOR))
 testArgs += -race
 endif


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15682

Remove the `DISABLE_COVERAGE` flag. The only thing that this does is when you run `make test-<package>`, it adds a summary line at the end of the go test output to include the percentage of lines covered that looks like this:
```
coverage:  <N>% of statements
```
I don't think this is particularly useful - instead, it's more useful is to run `make coverage-<package>` or `make html-coverage-<package>`, which produces more detailed information about code coverage rather than a single aggregate coverage number. Those coverage targets do not depend on `DISABLE_COVERAGE`.