### PR TITLE
EVG-18207: Only explicitly exit on SIGINT, SIGKILL, and SIGHUP.

### DIFF
--- a/operations/buildlogger.go
+++ b/operations/buildlogger.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"strings"
+	"syscall"
 	"time"
 
 	shlex "github.com/anmitsu/go-shlex"
@@ -391,7 +392,7 @@ func (l *cmdLogger) followFile(fn string) error {
 	}()
 
 	c := make(chan os.Signal, 1)
-	signal.Notify(c)
+	signal.Notify(c, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 	s := <-c
 	grip.Notice(fmt.Sprintf("got signal: %s", s))
 	end <- 0


### PR DESCRIPTION
We only need to do this handling so that we can make a best effort at reading to the end of the file before we close, so it only makes sense to handles signals with a default "Terminate" action that users would likely use to control the file tailing.

None of the other signals look likely to be used for control by external processes, and the remaining signals that are ignored or have other actions probably shouldn't be specially handled by us.

This fixes an issue where we were killing our process on SIGURG.