### PR TITLE
DEVPROD-7875: Update Curator to include perf-rollups

### DIFF
--- a/cmd/curator/curator.go
+++ b/cmd/curator/curator.go
@@ -51,6 +51,7 @@ func buildApp() *cli.App {
 		operations.FTDC(),
 		operations.Timber(),
 		operations.Backup(),
+		operations.CalculateRollups(),
 	}
 
 	// These are global options. Use this to configure logging or

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mongodb/curator
 go 1.20
 
 require (
+	github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794
 	github.com/anmitsu/go-shlex v0.0.0-20200514113438-38f4b401e2be
 	github.com/blang/semver v3.5.1+incompatible
 	github.com/evergreen-ci/aviation v0.0.0-20220405151811-ff4a78a4297c

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/Shopify/logrus-bugsnag v0.0.0-20171204204709-577dee27f20d/go.mod h1:H
 github.com/StackExchange/wmi v1.2.1/go.mod h1:rcmrprowKIVzvc+NUiLncP2uuArMWLCbu9SBzvHz7e8=
 github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1ow=
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
+github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794 h1:xlwdaKcTNVW4PtpQb8aKA4Pjy0CdJHEqvFbAnvR5m2g=
+github.com/aclements/go-moremath v0.0.0-20210112150236-f10218a38794/go.mod h1:7e+I0LQFUI9AXWxOfsQROs9xPhoJtbsyWcjJqDd4KPY=
 github.com/ajstarks/deck v0.0.0-20200831202436-30c9fc6549a9/go.mod h1:JynElWSGnm/4RlzPXRlREEwqTHAN3T56Bv2ITsFT3gY=
 github.com/ajstarks/deck/generate v0.0.0-20210309230005-c3f852c02e19/go.mod h1:T13YZdzov6OU0A1+RfKZiZN9ca6VeKdBdyDV+BY97Tk=
 github.com/ajstarks/svgo v0.0.0-20180226025133-644b8db467af/go.mod h1:K08gAheRH3/J6wwsYMMT4xOr94bZjxIelGM0+d/wbFw=

--- a/operations/rollups.go
+++ b/operations/rollups.go
@@ -1,0 +1,67 @@
+package operations
+
+import (
+	"context"
+	"os"
+
+	"github.com/evergreen-ci/utility"
+	"github.com/mongodb/curator/operations/rollups"
+	"github.com/mongodb/ftdc"
+	"github.com/pkg/errors"
+	"github.com/urfave/cli"
+)
+
+const (
+	ftdcFileLocation = "inputFile"
+	rollupOutputFile = "outputFile"
+)
+
+type CedarInputData struct {
+	Name          string
+	Value         interface{}
+	Type          string
+	UserSubmitted bool
+}
+
+func CalculateRollups() cli.Command {
+	return cli.Command{
+		Name:  "calculate-rollups",
+		Usage: "Create a rollup of performance data from a FTDC file",
+		Flags: []cli.Flag{cli.StringFlag{
+			Name:  ftdcFileLocation,
+			Usage: "Specify where the FTDC file to calculate is located",
+		}, cli.StringFlag{
+			Name:  rollupOutputFile,
+			Usage: "Specify where to output the rollup file",
+		}},
+		Action: func(c *cli.Context) error {
+			ctx, cancel := context.WithCancel(context.Background())
+			defer cancel()
+
+			fileName := c.String(ftdcFileLocation)
+			outputFileName := c.String(rollupOutputFile)
+
+			fileData, err := os.Open(fileName)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+			ftdcData := ftdc.ReadChunks(ctx, fileData)
+
+			rollupData, err := rollups.CalculateDefaultRollups(ftdcData, false)
+			if err != nil {
+				return errors.WithStack(err)
+			}
+			formattedRollupData := []CedarInputData{}
+			for _, data := range rollupData {
+				formattedRollupData = append(formattedRollupData, CedarInputData{
+					Name:          data.Name,
+					Value:         data.Value,
+					Type:          string(data.MetricType),
+					UserSubmitted: data.UserSubmitted,
+				})
+			}
+
+			return errors.WithStack(utility.WriteJSONFile(outputFileName, formattedRollupData))
+		},
+	}
+}

--- a/operations/rollups/helpers.go
+++ b/operations/rollups/helpers.go
@@ -1,0 +1,22 @@
+package rollups
+
+func convertToFloats(ints []int64) []float64 {
+	floats := []float64{}
+	for i := range ints {
+		floats = append(floats, float64(ints[i]))
+	}
+
+	return floats
+}
+
+// expects slice of cumulative values
+func extractValues(vals []float64, lastValue float64) []float64 {
+	extractedVals := make([]float64, len(vals))
+
+	for i := range vals {
+		extractedVals[i] = vals[i] - lastValue
+		lastValue = vals[i]
+	}
+
+	return extractedVals
+}

--- a/operations/rollups/metrics.go
+++ b/operations/rollups/metrics.go
@@ -1,0 +1,464 @@
+package rollups
+
+import (
+	"sort"
+
+	"github.com/aclements/go-moremath/stats"
+)
+
+type MetricType string
+
+const (
+	MetricTypeMean         MetricType = "mean"
+	MetricTypeMedian       MetricType = "median"
+	MetricTypeMax          MetricType = "max"
+	MetricTypeMin          MetricType = "min"
+	MetricTypeSum          MetricType = "sum"
+	MetricTypeStdDev       MetricType = "standard-deviation"
+	MetricTypePercentile99 MetricType = "percentile-99th"
+	MetricTypePercentile90 MetricType = "percentile-90th"
+	MetricTypePercentile95 MetricType = "percentile-95th"
+	MetricTypePercentile80 MetricType = "percentile-80th"
+	MetricTypePercentile50 MetricType = "percentile-50th"
+	MetricTypeThroughput   MetricType = "throughput"
+	MetricTypeLatency      MetricType = "latency"
+)
+
+//////////////////
+// Default Means
+//////////////////
+
+type latencyAverage struct{}
+
+const (
+	latencyAverageName    = "AverageLatency"
+	latencyAverageVersion = 3
+)
+
+func (f *latencyAverage) Type() string    { return latencyAverageName }
+func (f *latencyAverage) Names() []string { return []string{latencyAverageName} }
+func (f *latencyAverage) Version() int    { return latencyAverageVersion }
+func (f *latencyAverage) Calc(s *PerformanceStatistics, user bool) []PerfRollupValue {
+	rollup := PerfRollupValue{
+		Name:          latencyAverageName,
+		Version:       latencyAverageVersion,
+		MetricType:    MetricTypeMean,
+		UserSubmitted: user,
+	}
+
+	if s.counters.operationsTotal > 0 {
+		rollup.Value = float64(s.timers.durationTotal) / float64(s.counters.operationsTotal)
+	}
+
+	return []PerfRollupValue{rollup}
+}
+
+type sizeAverage struct{}
+
+const (
+	sizeAverageName    = "AverageSize"
+	sizeAverageVersion = 3
+)
+
+func (f *sizeAverage) Type() string    { return sizeAverageName }
+func (f *sizeAverage) Names() []string { return []string{sizeAverageName} }
+func (f *sizeAverage) Version() int    { return sizeAverageVersion }
+func (f *sizeAverage) Calc(s *PerformanceStatistics, user bool) []PerfRollupValue {
+	rollup := PerfRollupValue{
+		Name:          sizeAverageName,
+		Version:       sizeAverageVersion,
+		MetricType:    MetricTypeMean,
+		UserSubmitted: user,
+	}
+
+	if s.counters.operationsTotal > 0 {
+		rollup.Value = float64(s.counters.sizeTotal) / float64(s.counters.operationsTotal)
+	}
+
+	return []PerfRollupValue{rollup}
+}
+
+////////////////////////
+// Default Throughputs
+////////////////////////
+
+type operationThroughput struct{}
+
+const (
+	operationThroughputName    = "OperationThroughput"
+	operationThroughputVersion = 5
+)
+
+func (f *operationThroughput) Type() string    { return operationThroughputName }
+func (f *operationThroughput) Names() []string { return []string{operationThroughputName} }
+func (f *operationThroughput) Version() int    { return operationThroughputVersion }
+func (f *operationThroughput) Calc(s *PerformanceStatistics, user bool) []PerfRollupValue {
+	rollup := PerfRollupValue{
+		Name:          operationThroughputName,
+		Version:       operationThroughputVersion,
+		MetricType:    MetricTypeThroughput,
+		UserSubmitted: user,
+	}
+
+	if s.timers.totalWallTime > 0 {
+		rollup.Value = float64(s.counters.operationsTotal) / s.timers.totalWallTime.Seconds()
+	}
+
+	return []PerfRollupValue{rollup}
+}
+
+type documentThroughput struct{}
+
+const (
+	documentThroughputName    = "DocumentThroughput"
+	documentThroughputVersion = 1
+)
+
+func (f *documentThroughput) Type() string    { return documentThroughputName }
+func (f *documentThroughput) Names() []string { return []string{documentThroughputName} }
+func (f *documentThroughput) Version() int    { return documentThroughputVersion }
+func (f *documentThroughput) Calc(s *PerformanceStatistics, user bool) []PerfRollupValue {
+	rollup := PerfRollupValue{
+		Name:          documentThroughputName,
+		Version:       documentThroughputVersion,
+		MetricType:    MetricTypeThroughput,
+		UserSubmitted: user,
+	}
+
+	if s.timers.totalWallTime > 0 {
+		rollup.Value = float64(s.counters.documentsTotal) / s.timers.totalWallTime.Seconds()
+	}
+
+	return []PerfRollupValue{rollup}
+}
+
+type sizeThroughput struct{}
+
+const (
+	sizeThroughputName    = "SizeThroughput"
+	sizeThroughputVersion = 5
+)
+
+func (f *sizeThroughput) Type() string    { return sizeThroughputName }
+func (f *sizeThroughput) Names() []string { return []string{sizeThroughputName} }
+func (f *sizeThroughput) Version() int    { return sizeThroughputVersion }
+func (f *sizeThroughput) Calc(s *PerformanceStatistics, user bool) []PerfRollupValue {
+	rollup := PerfRollupValue{
+		Name:          sizeThroughputName,
+		Version:       sizeThroughputVersion,
+		MetricType:    MetricTypeThroughput,
+		UserSubmitted: user,
+	}
+	if s.timers.totalWallTime > 0 {
+		rollup.Value = float64(s.counters.sizeTotal) / s.timers.totalWallTime.Seconds()
+	}
+
+	return []PerfRollupValue{rollup}
+}
+
+type errorThroughput struct{}
+
+const (
+	errorThroughputName    = "ErrorRate"
+	errorThroughputVersion = 5
+)
+
+func (f *errorThroughput) Type() string    { return errorThroughputName }
+func (f *errorThroughput) Names() []string { return []string{errorThroughputName} }
+func (f *errorThroughput) Version() int    { return errorThroughputVersion }
+func (f *errorThroughput) Calc(s *PerformanceStatistics, user bool) []PerfRollupValue {
+	rollup := PerfRollupValue{
+		Name:          errorThroughputName,
+		Version:       errorThroughputVersion,
+		MetricType:    MetricTypeThroughput,
+		UserSubmitted: user,
+	}
+
+	if s.timers.totalWallTime > 0 {
+		rollup.Value = float64(s.counters.errorsTotal) / s.timers.totalWallTime.Seconds()
+	}
+
+	return []PerfRollupValue{rollup}
+}
+
+////////////////////////
+// Default Percentiles
+////////////////////////
+
+type latencyPercentile struct{}
+
+const (
+	latencyPercentileName    = "LatencyPercentile"
+	latencyPercentile50Name  = "Latency50thPercentile"
+	latencyPercentile80Name  = "Latency80thPercentile"
+	latencyPercentile90Name  = "Latency90thPercentile"
+	latencyPercentile95Name  = "Latency95thPercentile"
+	latencyPercentile99Name  = "Latency99thPercentile"
+	latencyPercentileVersion = 4
+)
+
+func (f *latencyPercentile) Type() string { return latencyPercentileName }
+func (f *latencyPercentile) Names() []string {
+	return []string{
+		latencyPercentile50Name,
+		latencyPercentile80Name,
+		latencyPercentile90Name,
+		latencyPercentile95Name,
+		latencyPercentile99Name,
+	}
+}
+func (f *latencyPercentile) Version() int { return latencyPercentileVersion }
+func (f *latencyPercentile) Calc(s *PerformanceStatistics, user bool) []PerfRollupValue {
+	p50 := PerfRollupValue{
+		Name:          latencyPercentile50Name,
+		Version:       latencyPercentileVersion,
+		MetricType:    MetricTypePercentile50,
+		UserSubmitted: user,
+	}
+	p80 := PerfRollupValue{
+		Name:          latencyPercentile80Name,
+		Version:       latencyPercentileVersion,
+		MetricType:    MetricTypePercentile80,
+		UserSubmitted: user,
+	}
+	p90 := PerfRollupValue{
+		Name:          latencyPercentile90Name,
+		Version:       latencyPercentileVersion,
+		MetricType:    MetricTypePercentile90,
+		UserSubmitted: user,
+	}
+	p95 := PerfRollupValue{
+		Name:          latencyPercentile95Name,
+		Version:       latencyPercentileVersion,
+		MetricType:    MetricTypePercentile95,
+		UserSubmitted: user,
+	}
+	p99 := PerfRollupValue{
+		Name:          latencyPercentile99Name,
+		Version:       latencyPercentileVersion,
+		MetricType:    MetricTypePercentile99,
+		UserSubmitted: user,
+	}
+
+	if len(s.timers.extractedDurations) > 0 {
+		durs := make(sort.Float64Slice, len(s.timers.extractedDurations))
+		copy(durs, s.timers.extractedDurations)
+		durs.Sort()
+		latencySample := stats.Sample{
+			Xs:     durs,
+			Sorted: true,
+		}
+		p50.Value = latencySample.Quantile(0.5)
+		p80.Value = latencySample.Quantile(0.8)
+		p90.Value = latencySample.Quantile(0.9)
+		p95.Value = latencySample.Quantile(0.95)
+		p99.Value = latencySample.Quantile(0.99)
+	}
+
+	return []PerfRollupValue{p50, p80, p90, p95, p99}
+}
+
+///////////////////
+// Default Bounds
+///////////////////
+
+type workersBounds struct{}
+
+const (
+	workersBoundsName    = "WorkersBounds"
+	workersMinName       = "WorkersMin"
+	workersMaxName       = "WorkersMax"
+	workersBoundsVersion = 3
+)
+
+func (f *workersBounds) Type() string    { return workersBoundsName }
+func (f *workersBounds) Names() []string { return []string{workersMinName, workersMaxName} }
+func (f *workersBounds) Version() int    { return workersBoundsVersion }
+func (f *workersBounds) Calc(s *PerformanceStatistics, user bool) []PerfRollupValue {
+	min := PerfRollupValue{
+		Name:          workersMinName,
+		Version:       workersBoundsVersion,
+		MetricType:    MetricTypeMin,
+		UserSubmitted: user,
+	}
+	max := PerfRollupValue{
+		Name:          workersMaxName,
+		Version:       workersBoundsVersion,
+		MetricType:    MetricTypeMax,
+		UserSubmitted: user,
+	}
+	if len(s.gauges.workers) > 0 {
+		min.Value, max.Value = stats.Sample{Xs: s.gauges.workers}.Bounds()
+	}
+
+	return []PerfRollupValue{min, max}
+}
+
+type latencyBounds struct{}
+
+const (
+	latencyBoundsName    = "LatencyBounds"
+	latencyMinName       = "LatencyMin"
+	latencyMaxName       = "LatencyMax"
+	latencyBoundsVersion = 4
+)
+
+func (f *latencyBounds) Type() string    { return latencyBoundsName }
+func (f *latencyBounds) Names() []string { return []string{latencyMinName, latencyMaxName} }
+func (f *latencyBounds) Version() int    { return latencyBoundsVersion }
+func (f *latencyBounds) Calc(s *PerformanceStatistics, user bool) []PerfRollupValue {
+	min := PerfRollupValue{
+		Name:          latencyMinName,
+		Version:       latencyBoundsVersion,
+		MetricType:    MetricTypeMin,
+		UserSubmitted: user,
+	}
+	max := PerfRollupValue{
+		Name:          latencyMaxName,
+		Version:       latencyBoundsVersion,
+		MetricType:    MetricTypeMax,
+		UserSubmitted: user,
+	}
+
+	if len(s.timers.extractedDurations) > 0 {
+		min.Value, max.Value = stats.Sample{Xs: s.timers.extractedDurations}.Bounds()
+	}
+
+	return []PerfRollupValue{min, max}
+}
+
+/////////////////
+// Default Sums
+/////////////////
+
+type durationSum struct{}
+
+const (
+	durationSumName    = "DurationTotal"
+	durationSumVersion = 5
+)
+
+func (f *durationSum) Type() string    { return durationSumName }
+func (f *durationSum) Names() []string { return []string{durationSumName} }
+func (f *durationSum) Version() int    { return durationSumVersion }
+func (f *durationSum) Calc(s *PerformanceStatistics, user bool) []PerfRollupValue {
+	return []PerfRollupValue{
+		{
+			Name:          durationSumName,
+			Value:         s.timers.totalWallTime,
+			Version:       durationSumVersion,
+			MetricType:    MetricTypeSum,
+			UserSubmitted: user,
+		},
+	}
+}
+
+type errorsSum struct{}
+
+const (
+	errorsSumName    = "ErrorsTotal"
+	errorsSumVersion = 3
+)
+
+func (f *errorsSum) Type() string    { return errorsSumName }
+func (f *errorsSum) Names() []string { return []string{errorsSumName} }
+func (f *errorsSum) Version() int    { return errorsSumVersion }
+func (f *errorsSum) Calc(s *PerformanceStatistics, user bool) []PerfRollupValue {
+	return []PerfRollupValue{
+		{
+			Name:          errorsSumName,
+			Value:         s.counters.errorsTotal,
+			Version:       errorsSumVersion,
+			MetricType:    MetricTypeSum,
+			UserSubmitted: user,
+		},
+	}
+}
+
+type operationsSum struct{}
+
+const (
+	operationsSumName    = "OperationsTotal"
+	operationsSumVersion = 3
+)
+
+func (f *operationsSum) Type() string    { return operationsSumName }
+func (f *operationsSum) Names() []string { return []string{operationsSumName} }
+func (f *operationsSum) Version() int    { return operationsSumVersion }
+func (f *operationsSum) Calc(s *PerformanceStatistics, user bool) []PerfRollupValue {
+	return []PerfRollupValue{
+		{
+			Name:          operationsSumName,
+			Value:         s.counters.operationsTotal,
+			Version:       operationsSumVersion,
+			MetricType:    MetricTypeSum,
+			UserSubmitted: user,
+		},
+	}
+}
+
+type documentsSum struct{}
+
+const (
+	documentsSumName    = "DocumentsTotal"
+	documentsSumVersion = 0
+)
+
+func (f *documentsSum) Type() string    { return documentsSumName }
+func (f *documentsSum) Names() []string { return []string{documentsSumName} }
+func (f *documentsSum) Version() int    { return documentsSumVersion }
+func (f *documentsSum) Calc(s *PerformanceStatistics, user bool) []PerfRollupValue {
+	return []PerfRollupValue{
+		{
+			Name:          documentsSumName,
+			Value:         s.counters.documentsTotal,
+			Version:       documentsSumVersion,
+			MetricType:    MetricTypeSum,
+			UserSubmitted: user,
+		},
+	}
+}
+
+type sizeSum struct{}
+
+const (
+	sizeSumName    = "SizeTotal"
+	sizeSumVersion = 3
+)
+
+func (f *sizeSum) Type() string    { return sizeSumName }
+func (f *sizeSum) Names() []string { return []string{sizeSumName} }
+func (f *sizeSum) Version() int    { return sizeSumVersion }
+func (f *sizeSum) Calc(s *PerformanceStatistics, user bool) []PerfRollupValue {
+	return []PerfRollupValue{
+		{
+			Name:          sizeSumName,
+			Value:         s.counters.sizeTotal,
+			Version:       sizeSumVersion,
+			MetricType:    MetricTypeSum,
+			UserSubmitted: user,
+		},
+	}
+}
+
+type overheadSum struct{}
+
+const (
+	overheadSumName    = "OverheadTotal"
+	overheadSumVersion = 1
+)
+
+func (f *overheadSum) Type() string    { return overheadSumName }
+func (f *overheadSum) Names() []string { return []string{overheadSumName} }
+func (f *overheadSum) Version() int    { return overheadSumVersion }
+func (f *overheadSum) Calc(s *PerformanceStatistics, user bool) []PerfRollupValue {
+	return []PerfRollupValue{
+		{
+			Name:          overheadSumName,
+			Value:         s.timers.total - s.timers.durationTotal,
+			Version:       overheadSumVersion,
+			MetricType:    MetricTypeSum,
+			UserSubmitted: user,
+		},
+	}
+}

--- a/operations/rollups/perf_rollups.go
+++ b/operations/rollups/perf_rollups.go
@@ -1,0 +1,178 @@
+package rollups
+
+import (
+	"time"
+
+	"github.com/mongodb/ftdc"
+	"github.com/pkg/errors"
+)
+
+const maxDurationsSize = 250000000
+
+type PerformanceStatistics struct {
+	counters struct {
+		operationsTotal int64
+		documentsTotal  int64
+		sizeTotal       int64
+		errorsTotal     int64
+	}
+
+	timers struct {
+		extractedDurations []float64
+		durationTotal      time.Duration
+		total              time.Duration
+		totalWallTime      time.Duration
+	}
+
+	gauges struct {
+		state   []float64
+		workers []float64
+		failed  []float64
+	}
+}
+
+type PerfRollupValue struct {
+	Name          string      `bson:"name"`
+	Value         interface{} `bson:"val"`
+	Version       int         `bson:"version"`
+	MetricType    MetricType  `bson:"type"`
+	UserSubmitted bool        `bson:"user"`
+}
+
+type RollupFactory interface {
+	Type() string
+	Names() []string
+	Version() int
+	Calc(*PerformanceStatistics, bool) []PerfRollupValue
+}
+
+var rollupsMap = map[string]RollupFactory{
+	latencyAverageName:      &latencyAverage{},
+	sizeAverageName:         &sizeAverage{},
+	operationThroughputName: &operationThroughput{},
+	documentThroughputName:  &documentThroughput{},
+	sizeThroughputName:      &sizeThroughput{},
+	errorThroughputName:     &errorThroughput{},
+	latencyPercentileName:   &latencyPercentile{},
+	workersBoundsName:       &workersBounds{},
+	latencyBoundsName:       &latencyBounds{},
+	durationSumName:         &durationSum{},
+	errorsSumName:           &errorsSum{},
+	operationsSumName:       &operationsSum{},
+	documentsSumName:        &documentsSum{},
+	sizeSumName:             &sizeSum{},
+	overheadSumName:         &overheadSum{},
+}
+
+func RollupsMap() map[string]RollupFactory {
+	return rollupsMap
+}
+
+func RollupFactoryFromType(t string) RollupFactory {
+	return rollupsMap[t]
+}
+
+var defaultRollups = []RollupFactory{
+	&latencyAverage{},
+	&sizeAverage{},
+	&operationThroughput{},
+	&documentThroughput{},
+	&sizeThroughput{},
+	&errorThroughput{},
+	&latencyPercentile{},
+	&workersBounds{},
+	&latencyBounds{},
+	&durationSum{},
+	&errorsSum{},
+	&operationsSum{},
+	&documentsSum{},
+	&sizeSum{},
+	&overheadSum{},
+}
+
+func DefaultRollupFactories() []RollupFactory { return defaultRollups }
+
+func CalculateDefaultRollups(dx *ftdc.ChunkIterator, user bool) ([]PerfRollupValue, error) {
+	rollups := []PerfRollupValue{}
+
+	perfStats, err := CreatePerformanceStats(dx)
+	if err != nil {
+		return rollups, errors.Wrap(err, "calculating perf statistics")
+	}
+
+	factories := DefaultRollupFactories()
+	for _, factory := range factories {
+		rollups = append(rollups, factory.Calc(perfStats, user)...)
+	}
+
+	return rollups, nil
+}
+
+func CreatePerformanceStats(dx *ftdc.ChunkIterator) (*PerformanceStatistics, error) {
+	perfStats := &PerformanceStatistics{}
+	lastValue := float64(0)
+	var firstTimestamp time.Time
+	var start time.Time
+	var end time.Time
+
+	defer dx.Close()
+	for i := 0; dx.Next(); i++ {
+		chunk := dx.Chunk()
+
+		for _, metric := range chunk.Metrics {
+			switch name := metric.Key(); name {
+			case "counters.ops":
+				perfStats.counters.operationsTotal = metric.Values[len(metric.Values)-1]
+			case "counters.n":
+				perfStats.counters.documentsTotal = metric.Values[len(metric.Values)-1]
+			case "counters.size":
+				perfStats.counters.sizeTotal = metric.Values[len(metric.Values)-1]
+			case "counters.errors":
+				perfStats.counters.errorsTotal = metric.Values[len(metric.Values)-1]
+			case "timers.duration", "timers.dur":
+				perfStats.timers.extractedDurations = append(
+					perfStats.timers.extractedDurations,
+					extractValues(convertToFloats(metric.Values), lastValue)...,
+				)
+				// In order to avoid memory panics, reject
+				// anything larger than 2GB.
+				if len(perfStats.timers.extractedDurations) > maxDurationsSize {
+					return nil, errors.New("size of ftdc file exceeds 2GB")
+				}
+				lastValue = float64(metric.Values[len(metric.Values)-1])
+				perfStats.timers.durationTotal = time.Duration(metric.Values[len(metric.Values)-1])
+			case "timers.total":
+				perfStats.timers.total = time.Duration(metric.Values[len(metric.Values)-1])
+			case "gauges.state":
+				perfStats.gauges.state = convertToFloats(metric.Values)
+			case "gauges.workers":
+				perfStats.gauges.workers = convertToFloats(metric.Values)
+			case "gauges.failed":
+				perfStats.gauges.failed = convertToFloats(metric.Values)
+			case "ts":
+				if i == 0 {
+					t := metric.Values[0]
+					firstTimestamp = time.Unix(t/1000, t%1000*1000000)
+				}
+				t := metric.Values[len(metric.Values)-1]
+				end = time.Unix(t/1000, t%1000*1000000)
+			case "id":
+				continue
+			default:
+				return nil, errors.Errorf("unknown field name '%s'", name)
+			}
+		}
+	}
+
+	// Since timestamps are at the end of operations, we need to subtract the
+	// first operation's duration from its timestamp to compute the total
+	// wallclock time including that first operation.
+	if len(perfStats.timers.extractedDurations) > 0 {
+		start = firstTimestamp.Add(-time.Duration(perfStats.timers.extractedDurations[0] * float64(time.Nanosecond)))
+	} else {
+		start = firstTimestamp
+	}
+	perfStats.timers.totalWallTime = end.Sub(start)
+
+	return perfStats, errors.WithStack(dx.Err())
+}


### PR DESCRIPTION
This adds a new CLI command to Curator open a local FTDC file and output a JSON rollup of the information in it.