### PR TITLE
DEVPROD-24160: do not enable CGO when compiling Ubuntu

### DIFF
--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -168,6 +168,19 @@ post:
 #           Buildvariants             #
 #######################################
 buildvariants:
+  # Race detector tests are intentionally run in a dedicated build variant
+  # because running tests with the race detector requires CGO to be enabled.
+  # Other build variants that compile and push artifacts need CGO to be disabled
+  # to build statically-linked binaries.
+  - name: race-detector
+    display_name: Race Detector
+    expansions:
+      GOROOT: /opt/golang/go1.24
+      RACE_DETECTOR: true
+    run_on:
+      - ubuntu2204-small
+    tasks:
+      - ".test"
 
   - name: lint
     display_name: Lint
@@ -198,7 +211,6 @@ buildvariants:
       - ubuntu2204-small
     expansions:
       GOROOT: /opt/golang/go1.24
-      RACE_DETECTOR: true
       goarch: amd64
       goos: linux
     tasks:


### PR DESCRIPTION
[DEVPROD-24160](https://jira.mongodb.org/browse/DEVPROD-24160)

[This commit](https://github.com/mongodb/curator/commit/a1293258b30e04ea503e6b91b6b1628789e90093) merged the race detector build variant into the Ubuntu one with the Go 1.20 upgrade. Unfortunately, merging the race detector build variant caused an undetected regression where the curator CLI went from being statically-linked to dynamically-linked. With race detector enabled, [the curator CLI will be built with CGO enabled](https://github.com/mongodb/curator/blob/02fb4d2fb9ff035f9a599508fffd184c2ea86f93/makefile#L58), which causes it to be dynamically linked (i.e. curator has to rely on an external glibc library that must be present on the host to be able to run). Older Linux distros won't have new enough glibc libraries, so we need the CLI to be statically-linked to ensure glibc is copied into the CLI when it's compiled.

I fixed this by splitting race detector back into its own build variant.

## Testing
* Verified that the Ubuntu compiled CLI was dynamically linked by curling the latest waterfal version and running `ldd ./curator`.
* Ran the same commands on [this patched version](https://spruce.mongodb.com/task/curator_ubuntu_build_patch_ad26912387fd471dc1eabd63a06b3555873079f2_6942c5f2a1e7240007c79a7b_25_12_17_15_02_10/files?execution=0) to verify that it's statically linked and `ldd ./curator` now outputs `not a dynamic executable`.